### PR TITLE
Bugfix: Fix text for UI color sliders

### DIFF
--- a/src/gui/src/UI/Settings/UITabAccount.js
+++ b/src/gui/src/UI/Settings/UITabAccount.js
@@ -37,6 +37,10 @@ export default {
         h += `<div style="overflow: hidden; display: flex; margin-bottom: 20px; flex-direction: column; align-items: center;">`;
             h += `<div class="profile-picture change-profile-picture" style="background-image: url('${html_encode(window.user?.profile?.picture ?? window.icons['profile.svg'])}');">`;
             h += `</div>`;
+            // load remove profile button on html refresh
+            if (window.user.profile.picture) {
+                h += `<button class="button button-small remove-profile-picture" style="margin-top: 10px;">${i18n('remove_profile_picture')}</button>`;
+            }
         h += `</div>`;
 
         // change password button
@@ -84,6 +88,18 @@ export default {
         return h;
     },
     init: ($el_window) => {
+        // function for removing profile picture
+        const removeProfilePicture = function() {
+            const default_image = window.icons['profile.svg'];
+            $el_window.find('.profile-picture').css('background-image', `url('${default_image}')`);
+            $('.profile-image').css('background-image', `url('${default_image}')`);
+            $('.profile-image').removeClass('profile-image-has-picture');
+            update_profile(window.user.username, {picture: null});
+            window.user.profile.picture = null;
+            // hide remove button
+            $el_window.find('.remove-profile-picture').hide();
+        };
+
         $el_window.find('.change-password').on('click', function (e) {
             UIWindowChangePassword({
                 window_options:{
@@ -149,6 +165,8 @@ export default {
                 selectable_body: false,
             });    
         })
+        // event delegation for remove profile pic buttons
+        $el_window.on('click', '.remove-profile-picture', removeProfilePicture);
 
         $el_window.on('file_opened', async function(e){
             let selected_file = Array.isArray(e.detail) ? e.detail[0] : e.detail;
@@ -173,7 +191,18 @@ export default {
                     $('.profile-image').css('background-image', 'url(' + html_encode(base64data) + ')');
                     $('.profile-image').addClass('profile-image-has-picture');
                     // update profile picture
-                    update_profile(window.user.username, {picture: base64data})
+                    update_profile(window.user.username, {picture: base64data});
+                    
+                    // show or create the remove button
+                    let remove_button = $el_window.find('.remove-profile-picture');
+                    // button doesn't exist, create it
+                    if (remove_button.length === 0) {
+                        const button_html = `<button class="button button-small remove-profile-picture" style="margin-top: 10px;">${i18n('remove_profile_picture')}</button>`;
+                        $el_window.find('.profile-picture').parent().append(button_html);
+                    } else {
+                        // button exists and is hidden
+                        remove_button.show();
+                    }
                 }
             }
         })

--- a/src/gui/src/UI/Settings/UITabAccount.js
+++ b/src/gui/src/UI/Settings/UITabAccount.js
@@ -23,6 +23,7 @@ import UIWindowChangeUsername from '../UIWindowChangeUsername.js';
 import UIWindowConfirmUserDeletion from './UIWindowConfirmUserDeletion.js';
 import UIWindowManageSessions from '../UIWindowManageSessions.js';
 import UIWindow from '../UIWindow.js';
+import UIAlert from '../UIAlert.js';
 
 // About
 export default {
@@ -89,15 +90,31 @@ export default {
     },
     init: ($el_window) => {
         // function for removing profile picture
-        const removeProfilePicture = function() {
-            const default_image = window.icons['profile.svg'];
-            $el_window.find('.profile-picture').css('background-image', `url('${default_image}')`);
-            $('.profile-image').css('background-image', `url('${default_image}')`);
-            $('.profile-image').removeClass('profile-image-has-picture');
-            update_profile(window.user.username, {picture: null});
-            window.user.profile.picture = null;
-            // hide remove button
-            $el_window.find('.remove-profile-picture').hide();
+        const removeProfilePicture = async function() {
+            // user confirmation
+            const alert_resp = await UIAlert({
+                message: i18n('confirm_delete_single_item'),
+                buttons: [
+                    {
+                        label: i18n('delete'),
+                        type: 'primary',
+                    },
+                    {
+                        label: i18n('cancel'),
+                    },
+                ]
+            });
+            
+            if (alert_resp === i18n('delete')) {
+                const default_image = window.icons['profile.svg'];
+                $el_window.find('.profile-picture').css('background-image', `url('${default_image}')`);
+                $('.profile-image').css('background-image', `url('${default_image}')`);
+                $('.profile-image').removeClass('profile-image-has-picture');
+                update_profile(window.user.username, {picture: null});
+                window.user.profile.picture = null;
+                // hide remove button
+                $el_window.find('.remove-profile-picture').hide();
+            }
         };
 
         $el_window.find('.change-password').on('click', function (e) {

--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -1218,7 +1218,7 @@ span.header-sort-icon img {
     margin: 0;
     font-weight: bold;
     font-size: 13px;
-    color: #8f96a3;
+    color: var(--window-sidebar-color);
     text-shadow: 1px 1px rgb(247 247 247 / 15%);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -1243,7 +1243,7 @@ span.header-sort-icon img {
     margin-top: 2px;
     padding: 4px;
     border-radius: 3px;
-    color: #444444;
+    color: var(--window-sidebar-color);
     font-size: 13px;
     cursor: pointer;
     transition: 0.15s background-color;
@@ -1256,6 +1256,7 @@ span.header-sort-icon img {
 
 .window-sidebar-item-active, .window-sidebar-item-drag-active, .window-sidebar-item-active:hover {
     background-color: #fefeff;
+    color: #444444;
 }
 
 .window-sidebar-item-placeholder {
@@ -1385,7 +1386,7 @@ span.header-sort-icon img {
     margin-right: 5px;
     margin-left: 10px;
     padding-bottom: 3px;
-    opacity: 0.6;
+    opacity: 0.7;
 }
 
 .window-active .window-action-btn {
@@ -1397,12 +1398,13 @@ span.header-sort-icon img {
     margin-top: 5px;
     margin-right: 4px;
     margin-left: 4px;
-    opacity: 0.5;
+    opacity: 0.6;
     -webkit-user-drag: none;
     user-select: none;
     -moz-user-select: none;
     -webkit-user-select: none;
     -ms-user-select: none;
+    filter: var(--window-action-btn-filter, invert(0));
 }
 
 .window-action-btn:hover>img {

--- a/src/gui/src/i18n/translations/ar.js
+++ b/src/gui/src/i18n/translations/ar.js
@@ -252,6 +252,7 @@ const ar = {
       refresh: "تحديث",
       release_address_confirmation: "هل أنت متأكد أنك تريد تحرير هذا العنوان؟",
       remove_from_taskbar: "إزالة من شريط المهام",
+      remove_profile_picture: "إزالة صورة الملف الشخصي",
       rename: "إعادة تسمية",
       repeat: "تكرار",
       replace: "استبدال",

--- a/src/gui/src/i18n/translations/bn.js
+++ b/src/gui/src/i18n/translations/bn.js
@@ -237,6 +237,7 @@ const bn = {
     refresh: "রিফ্রেশ",
     release_address_confirmation: `আপনি কি নিশ্চিত যে আপনি এই ঠিকানা রিলিজ করতে চান?`,
     remove_from_taskbar: "টাস্কবার থেকে সরান",
+    remove_profile_picture: "প্রোফাইল ছবি সরান",
     rename: "পুনঃনামকরণ",
     repeat: "পুনরাবৃত্তি",
     replace: "বদলান",

--- a/src/gui/src/i18n/translations/br.js
+++ b/src/gui/src/i18n/translations/br.js
@@ -235,6 +235,7 @@ const br = {
     "refresh": "Atualizar",
     "release_address_confirmation": "Tem certeza de que deseja liberar este endereço?",
     "remove_from_taskbar": "Remover da Barra de Tarefas",
+    "remove_profile_picture": "Remover Foto do Perfil",
     "rename": "Renomear",
     "repeat": "Repetir",
     "replace": "Substituir",

--- a/src/gui/src/i18n/translations/da.js
+++ b/src/gui/src/i18n/translations/da.js
@@ -234,6 +234,7 @@ const da = {
 		refresh: 'Opdater',
 		release_address_confirmation: `Er du sikker på, at du vil frigive denne adresse?`,
 		remove_from_taskbar: 'Fjern fra proceslinje',
+		remove_profile_picture: 'Fjern profilbillede',
 		rename: 'Omdøb',
 		repeat: 'Gentag',
 		replace: 'Erstat',

--- a/src/gui/src/i18n/translations/de.js
+++ b/src/gui/src/i18n/translations/de.js
@@ -234,6 +234,7 @@ const de = {
         refresh: 'Aktualisieren',
         release_address_confirmation: `Möchten Sie diese Adresse wirklich freigeben?`,
         remove_from_taskbar:'Von Taskleiste entfernen',
+        remove_profile_picture: 'Profilbild entfernen',
         rename: 'Umbenennen',
         repeat: 'Wiederholen',
         replace: 'Ersetzen',

--- a/src/gui/src/i18n/translations/emoji.js
+++ b/src/gui/src/i18n/translations/emoji.js
@@ -136,6 +136,7 @@ const emoji = {
         refresh: '🔄🔄',
         release_address_confirmation: `❓🆓`,
         remove_from_taskbar:'📌❌📁',
+        remove_profile_picture: '👤🗑️📷',
         rename: '🔄📛',
         repeat: '🔂',
         replace: '🔄🔄',

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -238,6 +238,7 @@ const en = {
         refresh: 'Refresh',
         release_address_confirmation: `Are you sure you want to release this address?`,
         remove_from_taskbar:'Remove from Taskbar',
+        remove_profile_picture:'Remove Profile Picture',
         rename: 'Rename',
         repeat: 'Repeat',
         replace: 'Replace',

--- a/src/gui/src/i18n/translations/es.js
+++ b/src/gui/src/i18n/translations/es.js
@@ -267,6 +267,7 @@ const es = {
     refresh: 'Refrescar',
     release_address_confirmation: `¿Estás seguro de que quieres liberar esta dirección?`,
     remove_from_taskbar: 'Eliminar de la barra de tareas',
+    remove_profile_picture: 'Eliminar Foto de Perfil',
     rename: 'Renombrar',
     repeat: 'Repetir',
     replace: 'Remplazar',

--- a/src/gui/src/i18n/translations/fa.js
+++ b/src/gui/src/i18n/translations/fa.js
@@ -135,6 +135,7 @@ const fa = {
     refresh: "تازه کردن",
     release_address_confirmation: `آیا مطمئن هستید که می خواهید این آدرس را آزاد کنید؟`,
     remove_from_taskbar: "از نوار وظایف حذف کن",
+    remove_profile_picture: "حذف تصویر پروفایل",
     rename: "تغییر نام",
     repeat: "تکرار",
     resend_confirmation_code: "ارسال مجدد کد تأیید",

--- a/src/gui/src/i18n/translations/fi.js
+++ b/src/gui/src/i18n/translations/fi.js
@@ -306,6 +306,7 @@ const fi = {
     // "publish" => "Oletko varma, että haluat julkaista tämän osoitteen?"
 
     remove_from_taskbar: "Poista tehtäväpalkista",
+    remove_profile_picture: 'Poista profiilikuva',
     rename: "Nimeä uudelleen",
     repeat: "Toista",
     replace: "Replace",

--- a/src/gui/src/i18n/translations/fr.js
+++ b/src/gui/src/i18n/translations/fr.js
@@ -234,6 +234,7 @@ const fr = {
         refresh: 'Actualiser',
         release_address_confirmation: `Etes-vous sûr de vouloir libérer cette adresse ?`,
         remove_from_taskbar: 'Retirer de la barre des tâches',
+        remove_profile_picture: 'Supprimer la photo de profil',
         rename: 'Renommer',
         repeat: 'Répéter',
         replace: 'Remplacer',

--- a/src/gui/src/i18n/translations/he.js
+++ b/src/gui/src/i18n/translations/he.js
@@ -250,6 +250,7 @@ const en = {
     refresh: "רענן",
     release_address_confirmation: `האם אתה בטוח שברצונך לשחרר כתובת זו?`,
     remove_from_taskbar: "הסרה משורת המשימות",
+    remove_profile_picture: 'הסר תמונת פרופיל',
     rename: "שנה שם",
     repeat: "חזור",
     replace: "החלף",

--- a/src/gui/src/i18n/translations/hi.js
+++ b/src/gui/src/i18n/translations/hi.js
@@ -234,6 +234,7 @@ const hi = {
         refresh: 'ताजा करना ',
         release_address_confirmation: "क्या आप वाकई यह पता जारी करना चाहते हैं?",
         remove_from_taskbar:'टास्कबार से हटाएँ',
+        remove_profile_picture: 'प्रोफाइल चित्र हटाएं',
         rename: 'नाम बदलें',
         repeat: 'दोहराना',
         replace: 'प्रतिस्थापित करें',

--- a/src/gui/src/i18n/translations/hu.js
+++ b/src/gui/src/i18n/translations/hu.js
@@ -230,6 +230,7 @@ const hu = {
         refresh: "Frissítés",
         release_address_confirmation: "Biztosan felszabadítod ezt a címet?",
         remove_from_taskbar: "Eltávolítás a tálcáról",
+        remove_profile_picture: 'Profilkép eltávolítása',
         rename: "Átnevezés",
         repeat: "Ismétlés",
         replace: "Csere",

--- a/src/gui/src/i18n/translations/hy.js
+++ b/src/gui/src/i18n/translations/hy.js
@@ -234,6 +234,7 @@ const hy = {
         refresh: "Թարմացնել",
         release_address_confirmation: "Իսկապե՞ս ուզում եք թողարկել այս հասցեն:",
         remove_from_taskbar: "Հանել խնդրագոտուց",
+        remove_profile_picture: 'Հեռացնել պրոֆիլի նկարը',
         rename: "Վերանվանել",
         repeat: "Կրկնել",
         replace: "Փոխարինել",

--- a/src/gui/src/i18n/translations/id.js
+++ b/src/gui/src/i18n/translations/id.js
@@ -251,6 +251,7 @@ const id = {
     refresh: "Memuat Ulang",
     release_address_confirmation: "Apakah Anda yakin ingin melepaskan alamat ini?",
     remove_from_taskbar: "Hapus dari Bilah Tugas",
+    remove_profile_picture: 'Hapus Foto Profil',
     rename: "Ganti Nama",
     repeat: "Ulangi",
     replace: "Ganti",

--- a/src/gui/src/i18n/translations/ig.js
+++ b/src/gui/src/i18n/translations/ig.js
@@ -255,6 +255,7 @@ const ig = {
     refresh: "Weghachite ume",
     release_address_confirmation: `O doro gị anya na ịchọrọ wepụtara adreesị a?`,
     remove_from_taskbar: "Wepu na Taskbar",
+    remove_profile_picture: 'Wepụ foto profaịlụ',
     rename: "Nyegharịa aha",
     repeat: "megharịa",
     replace: "Dochie",

--- a/src/gui/src/i18n/translations/it.js
+++ b/src/gui/src/i18n/translations/it.js
@@ -258,6 +258,7 @@ const it = {
     refresh: "Ricarica",
     release_address_confirmation: `Sei sicuro di voler liberare questo indirizzo?`,
     remove_from_taskbar: "Sblocca dalla barra delle applicazioni",
+    remove_profile_picture: 'Rimuovi immagine del profilo',
     rename: "Rinomina",
     repeat: "Ripeti",
     replace: "Sostituisci",

--- a/src/gui/src/i18n/translations/ja.js
+++ b/src/gui/src/i18n/translations/ja.js
@@ -235,6 +235,7 @@ const ja = {
         refresh: '更新',
         release_address_confirmation: `このアドレスを解放してもよろしいですか？`,
         remove_from_taskbar: 'タスクバーから削除',
+        remove_profile_picture: 'プロフィール画像を削除',
         rename: '名前を変更',
         repeat: '繰り返す',
         replace: '置換',

--- a/src/gui/src/i18n/translations/ko.js
+++ b/src/gui/src/i18n/translations/ko.js
@@ -253,6 +253,7 @@ const ko = {
     refresh: "새로 고침",
     release_address_confirmation: `이 주소를 해제하시겠습니까?`,
     remove_from_taskbar: "작업 표시줄에서 제거",
+    remove_profile_picture: '프로필 사진 제거',
     rename: "이름 변경",
     repeat: "반복",
     replace: "교체",

--- a/src/gui/src/i18n/translations/ku.js
+++ b/src/gui/src/i18n/translations/ku.js
@@ -259,6 +259,7 @@ const ku = {
     refresh: "بوژانەوە",
     release_address_confirmation: `دڵنیایت کە ئەتەوێت ئەم ناونیشانە بۆ هەڵگرتن؟`,
     remove_from_taskbar: "لابردن لە تاکسبار",
+    remove_profile_picture: 'وێنەی پڕۆفایل بسڕەوە',
     rename: "ناونانەوە",
     repeat: "دووبارەکردنەوە",
     replace: "لە نوێکردنەوە",

--- a/src/gui/src/i18n/translations/nb.js
+++ b/src/gui/src/i18n/translations/nb.js
@@ -136,6 +136,7 @@ const nb = {
         refresh: "Oppdater",
         release_address_confirmation: "Er du sikker på at du vil frigi denne adressen?",
         remove_from_taskbar: "Fjern fra oppgavelinjen",
+        remove_profile_picture: 'Fjern profilbilde',
         rename: "Gi nytt navn",
         repeat: "Gjenta",
         replace: 'Erstatt',

--- a/src/gui/src/i18n/translations/nl.js
+++ b/src/gui/src/i18n/translations/nl.js
@@ -235,6 +235,7 @@ const nl = {
 		refresh: 'Vernieuwen',
 		release_address_confirmation: `Weet je zeker dat je dit adres wilt vrijgeven?`,
 		remove_from_taskbar: 'Verwijderen van taakbalk',
+		remove_profile_picture: 'Profielfoto verwijderen',
 		rename: 'Hernoemen',
 		repeat: 'Herhalen',
 		replace: 'Vervangen',

--- a/src/gui/src/i18n/translations/nn.js
+++ b/src/gui/src/i18n/translations/nn.js
@@ -124,6 +124,7 @@ const nn = {
         refresh: "Oppdater",
         release_address_confirmation: "Er du sikker på at du vil sleppe denne adressa?",
         remove_from_taskbar: "Fjern frå oppgåvelinja",
+        remove_profile_picture: 'Fjern profilbilete',
         rename: "Gje nytt namn",
         repeat: "Gjenta",
         resend_confirmation_code: "Send stadfestingskoden på nytt",

--- a/src/gui/src/i18n/translations/pl.js
+++ b/src/gui/src/i18n/translations/pl.js
@@ -234,6 +234,7 @@ const pl = {
         refresh: 'Odśwież',
         release_address_confirmation: `Jesteś pewien, że chcesz wypuścić ten adres?`,
         remove_from_taskbar:'Usuń z paska zadań',
+        remove_profile_picture: 'Usuń zdjęcie profilowe',
         rename: 'Zmień nazwę',
         repeat: 'Powtarzaj',
         replace: 'Zamień',

--- a/src/gui/src/i18n/translations/pt.js
+++ b/src/gui/src/i18n/translations/pt.js
@@ -238,6 +238,7 @@ const pt = {
         refresh: 'Atualizar',
         release_address_confirmation: `Queres libertar este endereço?`,
         remove_from_taskbar:'Remover da Barra de Tarefas',
+        remove_profile_picture: 'Remover Foto do Perfil',
         rename: 'Renomear',
         repeat: 'Repetir',
         replace: 'Substituir',

--- a/src/gui/src/i18n/translations/ro.js
+++ b/src/gui/src/i18n/translations/ro.js
@@ -235,6 +235,7 @@ const ro = {
         refresh: 'Reîmprospătare',
         release_address_confirmation: `Sigur doriți să eliberați această adresă?`,
         remove_from_taskbar:'Eliminați din bara de activități',
+        remove_profile_picture: 'Eliminați poza de profil',
         rename: 'Redenumește',
         repeat: 'Repetă',
         replace: "Înlocuiește",

--- a/src/gui/src/i18n/translations/ru.js
+++ b/src/gui/src/i18n/translations/ru.js
@@ -258,6 +258,7 @@ const ru = {
     refresh: 'Обновить',
     release_address_confirmation: `Вы уверены, что хотите освободить этот адрес?`,
     remove_from_taskbar: 'Удалить из панели задач',
+    remove_profile_picture: 'Удалить фото профиля',
     rename: 'Переименовать',
     repeat: 'Повторить',
     replace: 'Заменить',

--- a/src/gui/src/i18n/translations/sv.js
+++ b/src/gui/src/i18n/translations/sv.js
@@ -235,6 +235,7 @@ const sv = {
         refresh: "Uppdatera",
         release_address_confirmation: "Är du säker på att du vill frigöra denna adress?",
         remove_from_taskbar: "Ta bort från aktivitetsfältet",
+        remove_profile_picture: 'Ta bort profilbild',
         rename: "Byt namn",
         repeat: "Upprepa",
         replace: "Ersätt",

--- a/src/gui/src/i18n/translations/ta.js
+++ b/src/gui/src/i18n/translations/ta.js
@@ -233,6 +233,7 @@ const ta = {
         refresh: 'புதுப்பிப்பு',
         release_address_confirmation: `இந்த முகவரியை நிச்சயமாக வெளியிட விரும்புகிறீர்களா?`,
         remove_from_taskbar: 'பணிப்பட்டியில் இருந்து அகற்று',
+        remove_profile_picture: 'சுயவிவரப் படத்தை அகற்று',
         rename: 'மறுபெயரிடவும்',
         repeat: 'மீண்டும் செய்யவும்',
         replace: 'மாற்றவும்',

--- a/src/gui/src/i18n/translations/th.js
+++ b/src/gui/src/i18n/translations/th.js
@@ -232,6 +232,7 @@ const th = {
         refresh: "รีเฟรช",
         release_address_confirmation: "คุณแน่ใจหรือไม่ว่าต้องการยกเลิกที่อยู่นี้?",
         remove_from_taskbar: "นำออกจากทาสก์บาร์",
+        remove_profile_picture: 'ลบรูปโปรไฟล์',
         rename: "เปลี่ยนชื่อ",
         repeat: "ทำซ้ำ",
         replace: "แทนที่",

--- a/src/gui/src/i18n/translations/tr.js
+++ b/src/gui/src/i18n/translations/tr.js
@@ -234,6 +234,7 @@ const tr = {
         refresh: "Yenile",
         release_address_confirmation: "Bu adresi bırakmak istediğinize emin misiniz?",
         remove_from_taskbar: "Görev Çubuğundan Kaldır",
+        remove_profile_picture: 'Profil resmini kaldır',
         rename: "Yeniden Adlandır",
         repeat: "Tekrarla",
         replace: "Değiştir",

--- a/src/gui/src/i18n/translations/ua.js
+++ b/src/gui/src/i18n/translations/ua.js
@@ -238,6 +238,7 @@ const ua = {
         refresh: "Оновити",
         release_address_confirmation: "Ви впевнені, що хочете звільнити цю адресу?",
         remove_from_taskbar: "Видалити з Панелі Завдань",
+        remove_profile_picture: 'Видалити фото профілю',
         rename: "Перейменувати",
         repeat: "Повторити",
         replace: "Замінити",

--- a/src/gui/src/i18n/translations/ur.js
+++ b/src/gui/src/i18n/translations/ur.js
@@ -242,6 +242,7 @@ const ur = {
     refresh: "تازہ کریں ",
     release_address_confirmation: "ایڈریس کی تصدیق جاری ",
     remove_from_taskbar: "ٹاسک بار سے ہٹائیں ",
+    remove_profile_picture: 'پروفائل تصویر ہٹائیں',
     rename: "دوبارہ نام دیں",
     repeat: "دہرایؐں",
     replace: "بدل دیں۔",

--- a/src/gui/src/i18n/translations/vi.js
+++ b/src/gui/src/i18n/translations/vi.js
@@ -235,6 +235,7 @@ const vi = {
         refresh: 'Làm mới',
         release_address_confirmation: `Bạn có chắc chắn muốn giải phóng địa chỉ này không?`,
         remove_from_taskbar: 'Xóa khỏi thanh tác vụ',
+        remove_profile_picture: 'Xóa ảnh đại diện',
         rename: 'Đổi tên',
         repeat: 'Lặp lại',
         replace: 'Thay thế',

--- a/src/gui/src/i18n/translations/zh.js
+++ b/src/gui/src/i18n/translations/zh.js
@@ -235,6 +235,7 @@ const zh = {
         refresh: '刷新',
         release_address_confirmation: `您确定要释放此地址吗？`,
         remove_from_taskbar:'从任务栏中删除',
+        remove_profile_picture: '删除头像',
         rename: '重命名',
         repeat: '重复',
         replace: '替换',

--- a/src/gui/src/i18n/translations/zhtw.js
+++ b/src/gui/src/i18n/translations/zhtw.js
@@ -234,6 +234,7 @@ const zhtw = {
         refresh: '重新整理',
         release_address_confirmation: `您確定要釋放此地址嗎？`,
         remove_from_taskbar: '從工作列移除',
+        remove_profile_picture: '移除個人資料圖片',
         rename: '重新命名',
         repeat: '重複',
         replace: '取代',

--- a/src/gui/src/services/ThemeService.js
+++ b/src/gui/src/services/ThemeService.js
@@ -35,6 +35,120 @@ const default_values = {
 export class ThemeService extends Service {
     #broadcastService;
 
+    /**
+     * Calculate relative luminance of a color according to WCAG guidelines
+     * @param {number} r - Red component (0-255)
+     * @param {number} g - Green component (0-255) 
+     * @param {number} b - Blue component (0-255)
+     * @returns {number} Relative luminance (0-1)
+     */
+    #calculateLuminance(r, g, b) {
+        // Convert to 0-1 range
+        r = r / 255;
+        g = g / 255;
+        b = b / 255;
+
+        // Apply gamma correction
+        const gammaCorrect = (c) => {
+            return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+        };
+
+        r = gammaCorrect(r);
+        g = gammaCorrect(g);
+        b = gammaCorrect(b);
+
+        // Calculate luminance using WCAG formula
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    }
+
+    /**
+     * Convert HSL color to RGB
+     * @param {number} h - Hue (0-360)
+     * @param {number} s - Saturation (0-100)
+     * @param {number} l - Lightness (0-100)
+     * @returns {Object} RGB values {r, g, b}
+     */
+    #hslToRgb(h, s, l) {
+        h = h / 360;
+        s = s / 100;
+        l = l / 100;
+
+        const hue2rgb = (p, q, t) => {
+            if (t < 0) t += 1;
+            if (t > 1) t -= 1;
+            if (t < 1/6) return p + (q - p) * 6 * t;
+            if (t < 1/2) return q;
+            if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
+            return p;
+        };
+
+        let r, g, b;
+
+        // If saturation == 0
+        if (s === 0) {
+            r = g = b = l; 
+        } else {
+            const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+            const p = 2 * l - q;
+            r = hue2rgb(p, q, h + 1/3);
+            g = hue2rgb(p, q, h);
+            b = hue2rgb(p, q, h - 1/3);
+        }
+
+        return {
+            r: Math.round(r * 255),
+            g: Math.round(g * 255),
+            b: Math.round(b * 255)
+        };
+    }
+
+    /**
+     * Calculate contrast ratio between two colors according to WCAG guidelines
+     * @param {number} luminance1 - Luminance of first color
+     * @param {number} luminance2 - Luminance of second color
+     * @returns {number} Contrast ratio (1-21)
+     */
+    #calculateContrastRatio(luminance1, luminance2) {
+        const lighter = Math.max(luminance1, luminance2);
+        const darker = Math.min(luminance1, luminance2);
+        return (lighter + 0.05) / (darker + 0.05);
+    }
+
+    /**
+     * Get the best accessible text color (white or dark) for a given background
+     * @param {number} hue - Background hue (0-360)
+     * @param {number} saturation - Background saturation (0-100)
+     * @param {number} lightness - Background lightness (0-100)
+     * @returns {Object} {color: '#ffffff' | '#373e44', contrastRatio: number, isAccessible: boolean}
+     */
+    #getAccessibleTextColor(hue, saturation, lightness) {
+        // Convert background to RGB then luminance
+        const bgRgb = this.#hslToRgb(hue, saturation, lightness);
+        const bgLuminance = this.#calculateLuminance(bgRgb.r, bgRgb.g, bgRgb.b);
+
+        // Test white text
+        const whiteLuminance = this.#calculateLuminance(255, 255, 255);
+        const whiteContrast = this.#calculateContrastRatio(bgLuminance, whiteLuminance);
+
+        // Test dark text
+        const darkRgb = { r: 0x37, g: 0x3e, b: 0x44 }; // #373e44
+        const darkLuminance = this.#calculateLuminance(darkRgb.r, darkRgb.g, darkRgb.b);
+        const darkContrast = this.#calculateContrastRatio(bgLuminance, darkLuminance);
+
+        // WCAG AA requires 4.5:1 for normal text, AAA requires 7:1
+        const minContrast = 4.5; // Use to add a confirmation modal for color picking
+        
+        if (whiteContrast >= darkContrast) {
+            return {
+                color: '#ffffff',
+            };
+        } else {
+            return {
+                color: '#373e44', 
+            };
+        }
+    }
+
     async _init () {
         this.#broadcastService = globalThis.services.get('broadcast');
 
@@ -116,11 +230,20 @@ export class ThemeService extends Service {
         //     }
         // `)
         // this.root.style.setProperty('--puter-window-background', `hsla(${s.hue}, ${s.sat}%, ${s.lig}%, ${s.alpha})`);
+
+        // Use WCAG calculations to determine the best text color
+        const accessibleText = this.#getAccessibleTextColor(s.hue, s.sat, s.lig);
+        const shouldUseLightText = accessibleText.color === '#ffffff';
+        
+        // Update light_text based on WCAG calculations
+        s.light_text = shouldUseLightText;
+
         this.root.style.setProperty('--primary-hue', s.hue);
         this.root.style.setProperty('--primary-saturation', s.sat + '%');
         this.root.style.setProperty('--primary-lightness', s.lig + '%');
         this.root.style.setProperty('--primary-alpha', s.alpha);
         this.root.style.setProperty('--primary-color', s.light_text ? 'white' : '#373e44');
+        this.root.style.setProperty('--window-action-btn-filter', s.light_text ? 'invert(1)' : 'invert(0)');
 
         // TODO: Should we debounce this to reduce traffic?
         this.#broadcastService.sendBroadcast('themeChanged', {

--- a/src/gui/src/services/ThemeService.js
+++ b/src/gui/src/services/ThemeService.js
@@ -51,13 +51,13 @@ export class ThemeService extends Service {
         b = b / 255;
 
         // Apply gamma correction
-        const gammaCorrect = (c) => {
+        const gamma_correct = (c) => {
             return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
         };
 
-        r = gammaCorrect(r);
-        g = gammaCorrect(g);
-        b = gammaCorrect(b);
+        r = gamma_correct(r);
+        g = gamma_correct(g);
+        b = gamma_correct(b);
 
         // Calculate luminance using WCAG formula
         return 0.2126 * r + 0.7152 * g + 0.0722 * b;
@@ -75,7 +75,7 @@ export class ThemeService extends Service {
         s = s / 100;
         l = l / 100;
 
-        const hue2rgb = (p, q, t) => {
+        const hue_2_rgb = (p, q, t) => {
             if (t < 0) t += 1;
             if (t > 1) t -= 1;
             if (t < 1/6) return p + (q - p) * 6 * t;
@@ -92,9 +92,9 @@ export class ThemeService extends Service {
         } else {
             const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
             const p = 2 * l - q;
-            r = hue2rgb(p, q, h + 1/3);
-            g = hue2rgb(p, q, h);
-            b = hue2rgb(p, q, h - 1/3);
+            r = hue_2_rgb(p, q, h + 1/3);
+            g = hue_2_rgb(p, q, h);
+            b = hue_2_rgb(p, q, h - 1/3);
         }
 
         return {
@@ -121,28 +121,28 @@ export class ThemeService extends Service {
      * @param {number} hue - Background hue (0-360)
      * @param {number} saturation - Background saturation (0-100)
      * @param {number} lightness - Background lightness (0-100)
-     * @returns {Object} {color: '#ffffff' | '#373e44', contrastRatio: number, isAccessible: boolean}
+     * @returns {Object} {color: '#ffffff' | '#373e44'}
      */
     #getAccessibleTextColor(hue, saturation, lightness) {
         // Convert background to RGB then luminance
-        const bgRgb = this.#hslToRgb(hue, saturation, lightness);
-        const bgLuminance = this.#calculateLuminance(bgRgb.r, bgRgb.g, bgRgb.b);
+        const bg_rgb = this.#hslToRgb(hue, saturation, lightness);
+        const bg_luminance = this.#calculateLuminance(bg_rgb.r, bg_rgb.g, bg_rgb.b);
 
         // Test white text
-        const whiteLuminance = this.#calculateLuminance(255, 255, 255);
-        const whiteContrast = this.#calculateContrastRatio(bgLuminance, whiteLuminance);
+        const white_luminance = this.#calculateLuminance(255, 255, 255);
+        const white_contrast = this.#calculateContrastRatio(bg_luminance, white_luminance);
 
         // Test dark text
-        const darkRgb = { r: 0x37, g: 0x3e, b: 0x44 }; // #373e44
-        const darkLuminance = this.#calculateLuminance(darkRgb.r, darkRgb.g, darkRgb.b);
-        const darkContrast = this.#calculateContrastRatio(bgLuminance, darkLuminance);
+        const dark_rgb = { r: 0x37, g: 0x3e, b: 0x44 }; // #373e44
+        const dark_luminance = this.#calculateLuminance(dark_rgb.r, dark_rgb.g, dark_rgb.b);
+        const dark_contrast = this.#calculateContrastRatio(bg_luminance, dark_luminance);
 
-        const minContrast = 4.5;
-        const bestContrast = Math.max(whiteContrast, darkContrast);
-        const roundedContrast = Math.round(bestContrast * 10) / 10; // Round to 1 decimal place
+        const min_contrast = 4.5;
+        const best_contrast = Math.max(white_contrast, dark_contrast);
+        const rounded_contrast = Math.round(best_contrast * 10) / 10; // Round to 1 decimal place
 
         // Use rounded contrast for comparison to avoid warnings for 4.45-4.49 range
-        if (roundedContrast < minContrast) {
+        if (rounded_contrast < min_contrast) {
             // Clear any existing timeout
             if (this.#contrastWarningTimeout) {
                 clearTimeout(this.#contrastWarningTimeout);
@@ -153,7 +153,7 @@ export class ThemeService extends Service {
                 const now = Date.now();
                 if (now - this.#lastContrastWarningShown > 5000) {
                     this.#lastContrastWarningShown = now;
-                    this.#showContrastWarning(roundedContrast);
+                    this.#showContrastWarning(rounded_contrast);
                 }
             }, 500);
         } else {
@@ -164,7 +164,7 @@ export class ThemeService extends Service {
             }
         }
 
-        if (whiteContrast >= darkContrast) {
+        if (white_contrast >= dark_contrast) {
             return {
                 color: '#ffffff',
             };
@@ -258,11 +258,11 @@ export class ThemeService extends Service {
         // this.root.style.setProperty('--puter-window-background', `hsla(${s.hue}, ${s.sat}%, ${s.lig}%, ${s.alpha})`);
 
         // Use WCAG calculations to determine the best text color
-        const accessibleText = this.#getAccessibleTextColor(s.hue, s.sat, s.lig);
-        const shouldUseLightText = accessibleText.color === '#ffffff';
+        const accessible_text = this.#getAccessibleTextColor(s.hue, s.sat, s.lig);
+        const use_light_text = accessible_text.color === '#ffffff';
         
         // Update light_text based on WCAG calculations
-        s.light_text = shouldUseLightText;
+        s.light_text = use_light_text;
 
         this.root.style.setProperty('--primary-hue', s.hue);
         this.root.style.setProperty('--primary-saturation', s.sat + '%');
@@ -299,12 +299,13 @@ export class ThemeService extends Service {
         ));
     }
 
-    async #showContrastWarning(contrastRatio) {
+    async #showContrastWarning(contrast_ratio) {
         try {
             await UIAlert({
                 message: `<strong>Accessibility Warning: </strong>
                           Color Contrast Below Standards
-                          <p>The selected colors have a contrast ratio of <strong>${contrastRatio.toFixed(1)}:1</strong>, which is below the WCAG AA recommendation of <strong>4.5:1.</strong></p>`,
+                          <p>The selected colors have a contrast ratio of <strong>${contrast_ratio.toFixed(1)}:1</strong>, which is below the WCAG AA recommendation of <strong>4.5:1</strong>.
+                          This might make the text a little harder to read.</p>`,
                 body_icon: window.icons['warning-sign.svg'],
                 buttons: [
                     {

--- a/src/gui/src/services/ThemeService.js
+++ b/src/gui/src/services/ThemeService.js
@@ -153,9 +153,9 @@ export class ThemeService extends Service {
                 const now = Date.now();
                 if (now - this.#lastContrastWarningShown > 5000) {
                     this.#lastContrastWarningShown = now;
-                    this.#showContrastWarning(roundedContrast); // Pass rounded value to warning
+                    this.#showContrastWarning(roundedContrast);
                 }
-            }, 500); // 1 second delay
+            }, 500);
         } else {
             // Good contrast - clear any pending warning
             if (this.#contrastWarningTimeout) {

--- a/src/gui/src/services/ThemeService.js
+++ b/src/gui/src/services/ThemeService.js
@@ -34,6 +34,8 @@ const default_values = {
 
 export class ThemeService extends Service {
     #broadcastService;
+    #lastContrastWarningShown = 0;
+    #contrastWarningTimeout = null; // Add timeout for debouncing
 
     /**
      * Calculate relative luminance of a color according to WCAG guidelines
@@ -135,9 +137,33 @@ export class ThemeService extends Service {
         const darkLuminance = this.#calculateLuminance(darkRgb.r, darkRgb.g, darkRgb.b);
         const darkContrast = this.#calculateContrastRatio(bgLuminance, darkLuminance);
 
-        // WCAG AA requires 4.5:1 for normal text, AAA requires 7:1
-        const minContrast = 4.5; // Use to add a confirmation modal for color picking
-        
+        const minContrast = 4.5;
+        const bestContrast = Math.max(whiteContrast, darkContrast);
+        const roundedContrast = Math.round(bestContrast * 10) / 10; // Round to 1 decimal place
+
+        // Use rounded contrast for comparison to avoid warnings for 4.45-4.49 range
+        if (roundedContrast < minContrast) {
+            // Clear any existing timeout
+            if (this.#contrastWarningTimeout) {
+                clearTimeout(this.#contrastWarningTimeout);
+            }
+            
+            // Set new timeout - warning will show 1/2 second after last change
+            this.#contrastWarningTimeout = setTimeout(() => {
+                const now = Date.now();
+                if (now - this.#lastContrastWarningShown > 5000) {
+                    this.#lastContrastWarningShown = now;
+                    this.#showContrastWarning(roundedContrast); // Pass rounded value to warning
+                }
+            }, 500); // 1 second delay
+        } else {
+            // Good contrast - clear any pending warning
+            if (this.#contrastWarningTimeout) {
+                clearTimeout(this.#contrastWarningTimeout);
+                this.#contrastWarningTimeout = null;
+            }
+        }
+
         if (whiteContrast >= darkContrast) {
             return {
                 color: '#ffffff',
@@ -272,4 +298,25 @@ export class ThemeService extends Service {
             5,
         ));
     }
+
+    async #showContrastWarning(contrastRatio) {
+        try {
+            await UIAlert({
+                message: `<strong>Accessibility Warning: </strong>
+                          Color Contrast Below Standards
+                          <p>The selected colors have a contrast ratio of <strong>${contrastRatio.toFixed(1)}:1</strong>, which is below the WCAG AA recommendation of <strong>4.5:1.</strong></p>`,
+                body_icon: window.icons['warning-sign.svg'],
+                buttons: [
+                    {
+                        label: 'Continue with these colors',
+                        value: 'continue',
+                        type: 'primary',
+                    }
+                ]
+            });
+        } catch (error) {
+            console.error('Error showing contrast warning:', error); // Add debugging
+        }
+    }
+
 }


### PR DESCRIPTION
## Title
Added contrast calculation methods to check that the text adheres to WCAG standards when paired with user's preferred UI colors.

## Description
Users can utilize the UI color sliders to customize the background on certain windows (settings window, file window, taskbar, etc.). The text color for the sidebar items in the file window was static and could not be seen well if the lightness was below 30%. After the commits, the text color is chosen dynamically depending on the color chosen by the user. The user also receives a popup if the color they chose is below WCAG standards.

## Testing
- slide UI slider in "Personalization" tab in "Settings" and see text color dynamically change depending on the color chosen
- if color is under 4.5:1 contrast ratio, a pop up appears to let users know that the text may be harder to read

## Checklist
   - [x] Code follows naming conventions and style guides
   - [x] All tests pass
   - [x] Documentation is updated
   - [x] No extraneous debug statements or commented-out code
   - [x] PR description clearly explains changes

## Screenshots
Before Screenshot: Text in sidebar is barely visible
<img width="1916" height="987" alt="before_screenshot" src="https://github.com/user-attachments/assets/52b4a0f4-d662-457d-a3a3-eabc7f5c9f84" />
After Screenshot: Text in sidebar can clearly be seen
<img width="1912" height="937" alt="after_screenshot" src="https://github.com/user-attachments/assets/85629752-6ded-4b1c-9763-c29c6a899d05" />

## Video Demo
https://youtu.be/-CwZ8HMImkY

Fixes Issue #5